### PR TITLE
Destroy

### DIFF
--- a/AnsiblePlaybooks/meerkat/run_meerkat.sh
+++ b/AnsiblePlaybooks/meerkat/run_meerkat.sh
@@ -36,5 +36,11 @@ cd ~/cloud-ops-tools/AnsiblePlaybooks/meerkat
 
 terraform init
 terraform destroy --auto-approve
+RESULT=$?
+if [ $RESULT != 0 ]; then
+	rm *.tfplan
+    rm *.tfstate*
+fi
+
 terraform plan -out=deploy.tfplan -lock=false -var "keypair_name=$KEYPAIR"
 terraform apply "deploy.tfplan"

--- a/AnsiblePlaybooks/meerkat/run_meerkat.sh
+++ b/AnsiblePlaybooks/meerkat/run_meerkat.sh
@@ -38,7 +38,7 @@ terraform init
 terraform destroy --auto-approve
 RESULT=$?
 if [ $RESULT != 0 ]; then
-	rm *.tfplan
+    rm *.tfplan
     rm *.tfstate*
 fi
 


### PR DESCRIPTION
a failsafe to allow Meerkat to keep running if destroy fails due to service being down, such as manila