### PR TITLE
split storage benchmarks into seperate roles

### DIFF
--- a/AnsiblePlaybooks/meerkat/deploy.tf
+++ b/AnsiblePlaybooks/meerkat/deploy.tf
@@ -94,7 +94,8 @@ resource "null_resource" "ansible_playbook" {
   depends_on = [openstack_compute_instance_v2.Instance, openstack_sharedfilesystem_share_v2.share, openstack_sharedfilesystem_share_access_v2.share_access, openstack_blockstorage_volume_v3.volumes, openstack_compute_volume_attach_v2.vol_attach]
   count = length(openstack_compute_instance_v2.Instance)
   provisioner "local-exec" {
-    command = "ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i staging-openstack.yaml -l ${local.vm_names[count.index]} ${var.playbook_path} --extra-vars 'share_path=${openstack_sharedfilesystem_share_v2.share.export_locations[0].path} access_key=${openstack_sharedfilesystem_share_access_v2.share_access.access_key} vm_count=${count.index}'"
+    command = "ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i staging-openstack.yaml -l ${local.vm_names[count.index]} ${var.playbook_path}"
+#    command = "ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i staging-openstack.yaml -l ${local.vm_names[count.index]} ${var.playbook_path} --extra-vars 'share_path=${openstack_sharedfilesystem_share_v2.share.export_locations[0].path} access_key=${openstack_sharedfilesystem_share_access_v2.share_access.access_key} vm_count=${count.index}'"
   }
 }
 

--- a/AnsiblePlaybooks/meerkat/meerkat.yaml
+++ b/AnsiblePlaybooks/meerkat/meerkat.yaml
@@ -19,9 +19,11 @@
     - role: setup_openstack
     - role: update_machine
     - role: setup_storage_benchmark
+    - role: run_local_storage_benchmark
     - role: attach_volume
+    - role: run_volume_storage_benchmark
     - role: attach_manila
-    - role: run_storage_benchmark
+    - role: run_manila_storage_benchmark
 
 
 - hosts: cpu

--- a/AnsiblePlaybooks/meerkat/roles/attach_manila/tasks/main.yaml
+++ b/AnsiblePlaybooks/meerkat/roles/attach_manila/tasks/main.yaml
@@ -1,20 +1,15 @@
-- name: Generate random string with length 12
-  ansible.builtin.debug:
-    var: lookup('community.general.random_string', length=12)
-  register: share_id
-
 - name: Mount ephemeral SMB volume
   ansible.posix.mount:
     src: "{{ share_path }}"
-    path: /mnt/manila_{{ share_id }}
-    opts: "name={{ user }},secret={{ access_key }}" 
+    path: /mnt/manila{{ vm_count }}
+    opts: "name={{ user }},secret={{ access_key }}"
     fstype: ceph
     state: ephemeral
   become: true
 
 - name: change manila folder owner
   ansible.builtin.file:
-    path: /mnt/manila_{{ share_id }}
-    owner: "{{ user  }}"
+    path: /mnt/manila{{ vm_count }}
+    owner: "{{ user }}"
     mode: '0664'
   become: true

--- a/AnsiblePlaybooks/meerkat/roles/attach_manila/tasks/main.yaml
+++ b/AnsiblePlaybooks/meerkat/roles/attach_manila/tasks/main.yaml
@@ -1,15 +1,20 @@
+- name: Generate random string with length 12
+  ansible.builtin.debug:
+    var: lookup('community.general.random_string', length=12)
+  register: share_id
+
 - name: Mount ephemeral SMB volume
   ansible.posix.mount:
     src: "{{ share_path }}"
-    path: /mnt/manila{{ vm_count }}
-    opts: "name={{ user }},secret={{ access_key }}"
+    path: /mnt/manila_{{ share_id }}
+    opts: "name={{ user }},secret={{ access_key }}" 
     fstype: ceph
     state: ephemeral
   become: true
 
 - name: change manila folder owner
   ansible.builtin.file:
-    path: /mnt/manila{{ vm_count }}
+    path: /mnt/manila_{{ share_id }}
     owner: "{{ user  }}"
     mode: '0664'
   become: true

--- a/AnsiblePlaybooks/meerkat/roles/run_local_storage_benchmark/tasks/main.yaml
+++ b/AnsiblePlaybooks/meerkat/roles/run_local_storage_benchmark/tasks/main.yaml
@@ -1,0 +1,2 @@
+- name: Run local storage benchmark
+  shell: "./benchmark.sh -p /home/{{ user }} -s local"

--- a/AnsiblePlaybooks/meerkat/roles/run_manila_storage_benchmark/tasks/main.yaml
+++ b/AnsiblePlaybooks/meerkat/roles/run_manila_storage_benchmark/tasks/main.yaml
@@ -1,0 +1,2 @@
+- name: Run manila share benchmark
+  shell: ./benchmark.sh -p /mnt/manila_{{ share_id }} -s manila

--- a/AnsiblePlaybooks/meerkat/roles/run_volume_storage_benchmark/tasks/main.yaml
+++ b/AnsiblePlaybooks/meerkat/roles/run_volume_storage_benchmark/tasks/main.yaml
@@ -1,0 +1,2 @@
+- name: Run volume storage benchmark
+  shell: ./benchmark.sh -p /mnt/volume -s volume

--- a/AnsiblePlaybooks/meerkat/variables.tf
+++ b/AnsiblePlaybooks/meerkat/variables.tf
@@ -30,7 +30,7 @@ variable "image_name" {
 
 variable "keypair_name" {
     description = "The keypair to be used"
-    default  = 
+    default  = "<ssh-key>"
 }
 
 variable "network_name" {


### PR DESCRIPTION
moved storage benchmarks in different roles allows for easier disabling of benchmarks